### PR TITLE
hash方式调用rpc时第一次建连异常修复

### DIFF
--- a/servant/libservant/EndpointManager.cpp
+++ b/servant/libservant/EndpointManager.cpp
@@ -954,7 +954,7 @@ AdapterProxy* EndpointManager::getHashProxyForWeight(int64_t hashCode, bool bSta
         }
 
         //被hash到的节点在主控是active的才走在流程
-        if (_vRegProxys[iIndex]->isActiveInReg() && _vRegProxys[iIndex]->checkActive())
+        if (_vRegProxys[iIndex]->isActiveInReg() && _vRegProxys[iIndex]->checkActive(_vRegProxys[iIndex]->isActive()))
         {
             return _vRegProxys[iIndex];
         }
@@ -1056,7 +1056,7 @@ AdapterProxy* EndpointManager::getConHashProxyForWeight(int64_t hashCode, bool b
         }
 
         //被hash到的节点在主控是active的才走在流程
-        if (_vRegProxys[iIndex]->isActiveInReg() && _vRegProxys[iIndex]->checkActive())
+        if (_vRegProxys[iIndex]->isActiveInReg() && _vRegProxys[iIndex]->checkActive(_vRegProxys[iIndex]->isActive()))
         {
             return _vRegProxys[iIndex];
         }
@@ -1347,7 +1347,7 @@ AdapterProxy* EndpointManager::getHashProxyForNormal(int64_t hashCode)
     }
 
     //被hash到的节点在主控是active的才走在流程
-    if (_vRegProxys[hash]->isActiveInReg() && _vRegProxys[hash]->checkActive())
+    if (_vRegProxys[hash]->isActiveInReg() && _vRegProxys[hash]->checkActive(_vRegProxys[hash]->isActive()))
     {
         return _vRegProxys[hash];
     }
@@ -1445,7 +1445,7 @@ AdapterProxy* EndpointManager::getConHashProxyForNormal(int64_t hashCode)
         }
 
         //被hash到的节点在主控是active的才走在流程
-        if (_vRegProxys[iIndex]->isActiveInReg() && _vRegProxys[iIndex]->checkActive())
+        if (_vRegProxys[iIndex]->isActiveInReg() && _vRegProxys[iIndex]->checkActive(_vRegProxys[iIndex]->isActive()))
         {
             return _vRegProxys[iIndex];
         }

--- a/servant/servant/AdapterProxy.h
+++ b/servant/servant/AdapterProxy.h
@@ -158,6 +158,11 @@ public:
     inline void setActiveInReg(bool bActive) { _activeStateInReg = bActive; }
 
     /**
+     * 节点当前的存活状态是否为active
+     */
+    inline bool isActive() { return _activeStatus; }
+
+    /**
      * 获取连接
      *
      * @return Transceiver*


### PR DESCRIPTION
修复hash模式rpc调用在超时没有rpc调用连接被服务端关闭或者第一次连接的时候会导致hash到错误的服务器